### PR TITLE
adds support for listing keys

### DIFF
--- a/lib/kv.js
+++ b/lib/kv.js
@@ -37,6 +37,9 @@ Kv.prototype.get = function(opts, callback) {
   };
 
   if (opts.recurse) req.query.recurse = 'true';
+  if (opts.keys) {
+    req.query.keys='true';
+  }
   if (opts.raw) {
     req.query.raw = 'true';
     req.buffer = true;
@@ -47,7 +50,7 @@ Kv.prototype.get = function(opts, callback) {
   this.consul._get(req, function(err, res) {
     if (res && res.statusCode === 404) return callback(undefined, undefined, res);
     if (err) return callback(err, undefined, res);
-    if (opts.raw) return callback(null, res.body, res);
+    if (opts.raw || opts.keys) return callback(null, res.body, res);
 
     if (res.body && Array.isArray(res.body)) {
       res.body.forEach(function(item) {


### PR DESCRIPTION
I've added ?keys parameter support to `consul.kv.get`, for listing keys. 
Listing keys is the only way to detect the removal of a key (maybe a bug in Consul ?).

Callback receives an array of strings.
