### PR TITLE
Add unref option to kv.get

### DIFF
--- a/lib/kv.js
+++ b/lib/kv.js
@@ -37,6 +37,7 @@ Kv.prototype.get = function(opts, callback) {
   };
 
   if (opts.recurse) req.query.recurse = 'true';
+  if (opts.unref) req.unref = true;
   if (opts.raw) {
     req.query.raw = 'true';
     req.buffer = true;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Consul client",
   "main": "./lib",
   "dependencies": {
-    "papi": "^0.16.1"
+    "papi": "authbox-lib/node-papi#0dab3f611ea028037903d852ee0d21b0be4b21fc"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
This requests that papi unref's the socket for the request if the given option is used with `get`.

The use case here is requests to update background information. The wait time can be set to ten minutes, but if the rest of the application is done there is no reason to continue waiting for a response. With the socket unref'd (see accompanying papi diff) the program exits cleanly.