### PR TITLE
Support new status option when registering checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Options
  * internal (String): interval to run check, requires script (ex: `15s`)
  * ttl (String): time to live before check must be updated, instead of script and interval (ex: `60s`)
  * notes (String, optional): human readable description of check
+ * status (String, optional): initial service status
 
 Usage
 
@@ -629,6 +630,7 @@ Options
   * internal (String): interval to run check, requires script (ex: `15s`)
   * ttl (String): time to live before check must be updated, instead of script and interval (ex: `60s`)
   * notes (String, optional): human readable description of check
+  * status (String, optional): initial service status
 
 Usage
 

--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -79,6 +79,7 @@ AgentCheck.prototype.register = function(opts, callback) {
       errors.Validation('http or script and interval, or ttl required'), req));
   }
   if (opts.hasOwnProperty('notes')) req.body.Notes = opts.notes;
+  if (opts.hasOwnProperty('status')) req.body.Status = opts.status;
 
   utils.options(req, opts);
 

--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -90,6 +90,7 @@ AgentService.prototype.register = function(opts, callback) {
         errors.Validation('http or script and interval, or ttl required'), req));
     }
     if (check.hasOwnProperty('notes')) req.body.Check.Notes = check.notes;
+    if (check.hasOwnProperty('status')) req.body.Check.Status = check.status;
   }
 
   utils.options(req, opts);

--- a/test/agent.js
+++ b/test/agent.js
@@ -90,6 +90,7 @@ describe('Agent', function() {
             HTTP: 'http://example.org/',
             Interval: '5s',
             Notes: 'http check',
+            Status: 'critical',
           })
           .reply(200);
 
@@ -100,6 +101,7 @@ describe('Agent', function() {
           http: 'http://example.org/',
           interval: '5s',
           notes: 'http check',
+          status: 'critical',
         };
 
         this.consul.agent.check.register(opts, function(err) {
@@ -410,6 +412,7 @@ describe('Agent', function() {
               HTTP: 'http://example.org/',
               Interval: '5s',
               Notes: 'http service check',
+              Status: 'critical',
             },
             Address: '10.0.0.1',
             Port: 80,
@@ -424,6 +427,7 @@ describe('Agent', function() {
             http: 'http://example.org/',
             interval: '5s',
             notes: 'http service check',
+            status: 'critical',
           },
           address: '10.0.0.1',
           port: 80,


### PR DESCRIPTION
Consul v0.5.1 supports a new `status` field when registering checks. This patch enables it for the relevant API adaptors. See https://github.com/hashicorp/consul/pull/859 for details on the new field.