### PR TITLE
Update service registration docs to include address and port options

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ Options
  * name (String): service name
  * id (String, optional): service ID
  * tags (String[], optional): service tags
+ * address (String, optional): service IP address
+ * port (Integer, optional): service port
  * check (Object, optional): service check
   * http (String): URL endpoint, requires interval
   * script (String): path to check script, requires interval


### PR DESCRIPTION
Just a minor update to the README.md to include `address` and `port` options to the `consul.agent.service.register` method.