### PR TITLE
Pass through unrestricted session options from lock to session.create

### DIFF
--- a/lib/lock.js
+++ b/lib/lock.js
@@ -155,11 +155,13 @@ Lock.prototype._session = function(ctx) {
   var self = this;
 
   if (!ctx.session.id) {
-    var opts = utils.defaults({
-      name: ctx.session.name || DEFAULT_LOCK_SESSION_NAME,
-      ttl: ctx.session.ttl || DEFAULT_LOCK_SESSION_TTL,
-      ctx: ctx,
-    }, self.consul._defaults);
+    ctx.session = utils.defaults(ctx.session, {
+      name: DEFAULT_LOCK_SESSION_NAME,
+      ttl: DEFAULT_LOCK_SESSION_TTL,
+      ctx: ctx
+    });
+
+    var opts = utils.defaults(ctx.session, self.consul._defaults);
 
     self.consul.session.create(opts, function(err, data, res) {
       if (err) {


### PR DESCRIPTION
It seems useful to be able to also specify lockdelay and possibly checks for the lock's session. This won't drop them (previously only name and ttl got through).