### PR TITLE
add tcp check option

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -210,9 +210,11 @@ function createCheck(src) {
   if (src.hasOwnProperty('name')) dst.Name = src.name;
   if (src.hasOwnProperty('serviceid')) dst.ServiceID = src.serviceid;
 
-  if ((src.http || src.script) && src.interval) {
+  if ((src.http || src.script || src.tcp) && src.interval) {
     if (src.http) {
       dst.HTTP = src.http;
+    } else if (src.tcp){
+      dst.TCP = src.tcp;
     } else {
       dst.Script = src.script;
       if (src.hasOwnProperty('dockercontainerid')) dst.DockerContainerID = src.dockercontainerid;


### PR DESCRIPTION
Since Consul 0.6.0 there is the TCP Health Check option, which is very similar to current HTTP/Script requirements.