### PR TITLE
Add toString to req.body.ID of consul.agent.service.register

### DIFF
--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -66,7 +66,7 @@ AgentService.prototype.register = function(opts, callback) {
   }
 
   req.body.Name = opts.name;
-  if (opts.id) req.body.ID = opts.id;
+  if (opts.id) req.body.ID = opts.id.toString();
   if (opts.tags) req.body.Tags = opts.tags;
   if (opts.hasOwnProperty('address')) req.body.Address = opts.address;
   if (opts.hasOwnProperty('port')) req.body.Port = opts.port;


### PR DESCRIPTION
```
consul.agent.service.register({
    "name": "casperx-manager",
    "id": 9939, // <= an interger
    "port": 9939,
    "address": "127.0.0.1",
    "check": {
        "http": "http://localhost:" + 9939 + "/health",
        "interval": "5s"
    }
}, function (err) {
    if (err) {
        console.log(err);
        throw err;
    }
});
```
That will result a `400 bad request`, because consul require a String id. So I add `toString()` to make sure `req.body.ID` is a String.