### PR TITLE
Acceptance test fixes to support Consul 0.6.x and later (issue #37)

### DIFF
--- a/test/acceptance/agent.js
+++ b/test/acceptance/agent.js
@@ -47,7 +47,7 @@ helper.describe('Agent', function() {
         should.not.exist(err);
 
         should(data).be.instanceOf(Object);
-        data.should.have.keys('Config', 'Member');
+        data.should.have.properties('Config', 'Member');
 
         data.Config.Bootstrap.should.be.true;
         data.Config.Server.should.be.true;

--- a/test/acceptance/catalog.js
+++ b/test/acceptance/catalog.js
@@ -85,7 +85,7 @@ helper.describe('Catalog', function() {
         this.c1.catalog.node.list(function(err, data) {
           should.not.exist(err);
 
-          should(data).eql([
+          should(data).match([
             { Node: 'node1', Address: '127.0.0.1' },
           ]);
 
@@ -97,7 +97,7 @@ helper.describe('Catalog', function() {
         this.c1.catalog.nodes('dc1', function(err, data) {
           should.not.exist(err);
 
-          should(data).eql([
+          should(data).match([
             { Node: 'node1', Address: '127.0.0.1' },
           ]);
 

--- a/test/acceptance/health.js
+++ b/test/acceptance/health.js
@@ -116,12 +116,12 @@ helper.describe('Health', function() {
 
         data[0].should.have.properties('Node', 'Service', 'Checks');
 
-        data[0].Node.should.eql({
+        data[0].Node.should.match({
           Node: 'node1',
           Address: '127.0.0.1',
         });
 
-        data[0].Service.should.eql({
+        data[0].Service.should.match({
           ID: self.service,
           Service: self.service,
           Tags: null,
@@ -129,11 +129,11 @@ helper.describe('Health', function() {
           Port: 0,
         });
 
-        var checks = data[0].Checks.map(function(c) { return c.CheckID; });
+        var checks = data[0].Checks.map(function(c) { return c.CheckID; }).sort();
 
         checks.should.eql([
-          'service:' + self.service,
           'serfHealth',
+          'service:' + self.service,
         ]);
 
         done();

--- a/test/acceptance/session.js
+++ b/test/acceptance/session.js
@@ -71,7 +71,7 @@ helper.describe('Session', function() {
       this.c1.session.get(this.id, function(err, session) {
         should.not.exist(err);
 
-        session.should.have.keys(
+        session.should.have.properties(
           'CreateIndex',
           'ID',
           'Name',
@@ -96,7 +96,7 @@ helper.describe('Session', function() {
         sessions.length.should.be.above(0);
 
         sessions.forEach(function(session) {
-          session.should.have.keys(
+          session.should.have.properties(
             'CreateIndex',
             'ID',
             'Name',
@@ -133,7 +133,7 @@ helper.describe('Session', function() {
         sessions.length.should.be.above(0);
 
         sessions.forEach(function(session) {
-          session.should.have.keys(
+          session.should.have.properties(
             'CreateIndex',
             'ID',
             'Name',
@@ -161,7 +161,7 @@ helper.describe('Session', function() {
 
         renew.should.not.be.empty;
 
-        should(renew[0]).keys(
+        should(renew[0]).properties(
           'CreateIndex',
           'ID',
           'Name',


### PR DESCRIPTION
Changes to allow extra keys (such as agent `Coord`, node `CreateIndex`/`ModifyIndex`/`TaggedAddresses`, and session `ModifyIndex`) and not assume checks are returned in a specifc order.