### PR TITLE
Add new check properties: Timeout and DeregisterCriticalServiceAfter

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,9 +503,12 @@ Options
  * dockercontainerid (String, optional): Docker container ID to run script
  * shell (String, optional): shell in which to run script (currently only supported with Docker)
  * interval (String): interval to run check, requires script (ex: `15s`)
- * ttl (String): time to live before check must be updated, instead of script and interval (ex: `60s`)
+ * timeout (String, optional): timeout for the check (ex: `10s`)
+ * ttl (String): time to live before check must be updated, instead of http/tcp/script and interval (ex: `60s`)
  * notes (String, optional): human readable description of check
  * status (String, optional): initial service status
+ * deregistercriticalserviceafter (String, optional, Consul 0.7+): timeout after
+ which to automatically deregister service if check remains in critical state
 
 Usage
 
@@ -643,11 +646,17 @@ Options
  * port (Integer, optional): service port
  * check (Object, optional): service check
    * http (String): URL endpoint, requires interval
+   * tcp (String): host:port to test, passes if connection is established, fails otherwise
    * script (String): path to check script, requires interval
+   * dockercontainerid (String, optional): Docker container ID to run script
+   * shell (String, optional): shell in which to run script (currently only supported with Docker)
    * interval (String): interval to run check, requires script (ex: `15s`)
-   * ttl (String): time to live before check must be updated, instead of http/script and interval (ex: `60s`)
+   * timeout (String, optional): timeout for the check (ex: `10s`)
+   * ttl (String): time to live before check must be updated, instead of http/tcp/script and interval (ex: `60s`)
    * notes (String, optional): human readable description of check
    * status (String, optional): initial service status
+   * deregistercriticalserviceafter (String, optional, Consul 0.7+): timeout after
+   which to automatically deregister service if check remains in critical state
  * checks (Object[], optional): service checks (see `check` above)
 
 Usage

--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -56,10 +56,6 @@ AgentCheck.prototype.register = function(opts, callback) {
     type: 'json',
   };
 
-  if (!opts.name) {
-    return callback(this.consul._err(errors.Validation('name required'), req));
-  }
-
   try {
     req.body = utils.createCheck(opts);
   } catch (err) {

--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -73,9 +73,9 @@ AgentService.prototype.register = function(opts, callback) {
 
   try {
     if (Array.isArray(opts.checks)) {
-      req.body.Checks = opts.checks.map(utils.createCheck);
+      req.body.Checks = opts.checks.map(utils.createServiceCheck);
     } else if (opts.check) {
-      req.body.Check = utils.createCheck(opts.check);
+      req.body.Check = utils.createServiceCheck(opts.check);
     }
   } catch (err) {
     return callback(this.consul._err(errors.Validation(err.message), req));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,17 +198,17 @@ function setIntervalContext(fn, ctx, timeout) {
 }
 
 /**
- * Create check object
+ * Create node/server-level check object
+ * Corresponds to CheckType in Consul Agent Endpoint:
+ * https://github.com/hashicorp/consul/blob/master/command/agent/check.go#L43
+ * Corresponds to AgentServiceCheck in Consul Go API (which currently omits Notes):
+ * https://github.com/hashicorp/consul/blob/master/api/agent.go#L66
+ * Currently omits ID and Name fields:
+ * https://github.com/hashicorp/consul/issues/2223
  */
 
-function createCheck(src) {
-  src = normalizeKeys(src);
-
+function _createServiceCheck(src) {
   var dst = {};
-
-  if (src.hasOwnProperty('id')) dst.ID = src.id;
-  if (src.hasOwnProperty('name')) dst.Name = src.name;
-  if (src.hasOwnProperty('serviceid')) dst.ServiceID = src.serviceid;
 
   if ((src.http || src.script || src.tcp) && src.interval) {
     if (src.http) {
@@ -221,13 +221,46 @@ function createCheck(src) {
       if (src.hasOwnProperty('shell')) dst.Shell = src.shell;
     }
     dst.Interval = src.interval;
+    if (src.hasOwnProperty('timeout')) dst.Timeout = src.timeout;
   } else if (src.ttl) {
     dst.TTL = src.ttl;
   } else {
-    throw new Error('http or script and interval, or ttl required');
+    throw new Error('http/tcp/script and interval, or ttl required');
   }
   if (src.hasOwnProperty('notes')) dst.Notes = src.notes;
   if (src.hasOwnProperty('status')) dst.Status = src.status;
+  if (src.hasOwnProperty('deregistercriticalserviceafter')) {
+    dst.DeregisterCriticalServiceAfter = src.deregistercriticalserviceafter;
+  }
+
+  return dst;
+}
+
+function createServiceCheck(src) {
+  return _createServiceCheck(normalizeKeys(src));
+}
+
+/**
+ * Create standalone check object
+ * Corresponds to CheckDefinition in Consul Agent Endpoint:
+ * https://github.com/hashicorp/consul/blob/master/command/agent/structs.go#L47
+ * Corresponds to AgentCheckRegistration in Consul Go API:
+ * https://github.com/hashicorp/consul/blob/master/api/agent.go#L57
+ */
+
+function createCheck(src) {
+  src = normalizeKeys(src);
+
+  var dst = _createServiceCheck(src);
+
+  if (src.name) {
+    dst.Name = src.name;
+  } else {
+    throw new Error('name required');
+  }
+
+  if (src.hasOwnProperty('id')) dst.ID = src.id;
+  if (src.hasOwnProperty('serviceid')) dst.ServiceID = src.serviceid;
 
   return dst;
 }
@@ -257,5 +290,6 @@ exports.clone = clone;
 exports.parseDuration = parseDuration;
 exports.setTimeoutContext = setTimeoutContext;
 exports.setIntervalContext = setIntervalContext;
+exports.createServiceCheck = createServiceCheck;
 exports.createCheck = createCheck;
 exports.hasIndexChanged = hasIndexChanged;

--- a/test/agent.js
+++ b/test/agent.js
@@ -167,14 +167,19 @@ describe('Agent', function() {
 
         this.consul.agent.check.register(opts, function(err) {
           should(err).property('message',
-            'consul: agent.check.register: http or script and interval, or ttl required');
+            'consul: agent.check.register: http/tcp/script and interval, or ttl required');
 
           done();
         });
       });
 
       it('should require name', function(done) {
-        this.consul.agent.check.register({}, function(err) {
+        var opts = {
+          http: 'http://localhost:5000/health',
+          interval: '10s',
+        };
+
+        this.consul.agent.check.register(opts, function(err) {
           should(err).property('message', 'consul: agent.check.register: name required');
 
           done();
@@ -542,7 +547,7 @@ describe('Agent', function() {
 
         this.consul.agent.service.register(opts, function(err) {
           should(err).property('message',
-            'consul: agent.service.register: http or script and interval, or ttl required');
+            'consul: agent.service.register: http/tcp/script and interval, or ttl required');
 
           done();
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -270,6 +270,7 @@ describe('utils', function() {
         name: 'name',
         service_id: 'service',
         http: 'http://127.0.0.1:8000',
+        timeout: '30s',
         interval: '60s',
         notes: 'Just a note.',
         status: 'passing',
@@ -278,6 +279,7 @@ describe('utils', function() {
         Name: 'name',
         ServiceID: 'service',
         HTTP: 'http://127.0.0.1:8000',
+        Timeout: '30s',
         Interval: '60s',
         Notes: 'Just a note.',
         Status: 'passing',
@@ -291,6 +293,7 @@ describe('utils', function() {
         interval: '10s',
         notes: 'SSH TCP on port 22',
         status: 'passing',
+        deregistercriticalserviceafter: '1h',
       })).eql({
         ID: 'id',
         Name: 'name',
@@ -299,9 +302,14 @@ describe('utils', function() {
         Interval: '10s',
         Notes: 'SSH TCP on port 22',
         Status: 'passing',
+        DeregisterCriticalServiceAfter: '1h',
       });
+    });
+  });
 
-      should(utils.createCheck({
+  describe('createServiceCheck', function() {
+    it('should work', function() {
+      should(utils.createServiceCheck({
         script: '/usr/bin/true',
         interval: '30s',
         shell: '/bin/sh',
@@ -313,17 +321,17 @@ describe('utils', function() {
         DockerContainerID: '123',
       });
 
-      should(utils.createCheck({
+      should(utils.createServiceCheck({
         ttl: '15s',
       })).eql({
         TTL: '15s',
       });
     });
 
-    it('should require script, http, or ttl', function() {
+    it('should require script, http, tcp, or ttl', function() {
       should(function() {
         utils.createCheck();
-      }).throw('http or script and interval, or ttl required');
+      }).throw('http/tcp/script and interval, or ttl required');
     });
   });
 


### PR DESCRIPTION
Also split checks into service-level and standalone (to match Consul's API and Agent Endpoint):
  * service-level checks ignore ID, Name, and ServiceID
  * standalone checks require Name