### PR TITLE
Create new opts object

### DIFF
--- a/lib/consul.js
+++ b/lib/consul.js
@@ -23,17 +23,18 @@ var Status = require('./status').Status;
 var Watch = require('./watch').Watch;
 var constants = require('./constants');
 var utils = require('./utils');
+var _ = require('lodash');
 
 /**
  * Initialize a new `Consul` client.
  */
 
-function Consul(opts) {
+function Consul(options) {
+  var opts = _.extend({}, options);
+
   if (!(this instanceof Consul)) {
     return new Consul(opts);
   }
-
-  opts = opts || {};
 
   if (!opts.baseUrl) {
     opts.baseUrl = (opts.secure ? 'https:' : 'http:') + '//' +

--- a/test/consul.js
+++ b/test/consul.js
@@ -65,6 +65,13 @@ describe('Consul', function() {
       hostname: 'example.org',
       path: '/proxy/v1',
     });
+
+  });
+
+  it('should create new opts object', function() {
+    var opts = {};
+
+    helper.consul(opts)._opts.should.not.exactly(opts);
   });
 
   describe('walk', function() {


### PR DESCRIPTION
Hello

2 days ago i started to use this lib for consul and very quickly i ran into a weird error where papi was yelling at the baseUrl. After some digging i found out that your library is actually mutating the options object that one pass in. So when using the same options object twice in your codebase you get weird errors

example:

File 1
```
var config = require('./config')

var consul = require('consul')(config.consul);
```

File 2
```
var config = require('./config')

var consul = require('consul')(config.consul);
```

Here file 2 breaks on initialization since the the first constructor have mutated my config.consul object. This is easy to fix by just creating new object but it took me a while to figure out why papi was breaking. I also think it's good practice to handle options params as "immutable" to avoid side effects like this.

I added test to make sure the object is not referenced and updated the opts to use _.extend from user options params.

Not a major thing but this would have saved me some trouble so I hope you think it's a good idea