### PR TITLE
Use PUT when the agent deregisters a service

### DIFF
--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -110,7 +110,7 @@ AgentService.prototype.deregister = function(opts, callback) {
 
   utils.options(req, opts);
 
-  this.consul._get(req, utils.empty, callback);
+  this.consul._put(req, utils.empty, callback);
 };
 
 /**

--- a/test/agent.js
+++ b/test/agent.js
@@ -567,7 +567,7 @@ describe('Agent', function() {
     describe('deregister', function() {
       it('should work', function(done) {
         this.nock
-          .get('/v1/agent/service/deregister/123')
+          .put('/v1/agent/service/deregister/123')
           .reply(200);
 
         var opts = { id: '123' };
@@ -581,7 +581,7 @@ describe('Agent', function() {
 
       it('should work with just id', function(done) {
         this.nock
-          .get('/v1/agent/service/deregister/123')
+          .put('/v1/agent/service/deregister/123')
           .reply(200);
 
         this.consul.agent.service.deregister('123', function(err) {


### PR DESCRIPTION
According to [Consul's documentation, when deregestering a service, a PUT request should be used](https://www.consul.io/api/agent/service.html#deregister-service) while in the code GET is used. This commit fixes that.