### PR TITLE
Changed HTTP verbs for Consul 1.0.0 breaking changes

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -133,6 +133,7 @@ Agent.prototype.join = function(opts, callback) {
     name: 'agent.join',
     path: '/agent/join/{address}',
     params: { address: opts.address },
+    method: 'PUT',
   };
 
   if (!opts.address) {
@@ -160,6 +161,7 @@ Agent.prototype.forceLeave = function(opts, callback) {
     name: 'agent.forceLeave',
     path: '/agent/force-leave/{node}',
     params: { node: opts.node },
+    method: 'PUT',
   };
 
   if (!opts.node) {

--- a/lib/agent/check.js
+++ b/lib/agent/check.js
@@ -54,6 +54,7 @@ AgentCheck.prototype.register = function(opts, callback) {
     name: 'agent.check.register',
     path: '/agent/check/register',
     type: 'json',
+    method: 'PUT',
   };
 
   try {
@@ -83,6 +84,7 @@ AgentCheck.prototype.deregister = function(opts, callback) {
     name: 'agent.check.deregister',
     path: '/agent/check/deregister/{id}',
     params: { id: opts.id },
+    method: 'PUT',
   };
 
   if (!opts.id) {
@@ -111,6 +113,7 @@ AgentCheck.prototype.pass = function(opts, callback) {
     path: '/agent/check/pass/{id}',
     params: { id: opts.id },
     query: {},
+    method: 'PUT',
   };
 
   if (!opts.id) {
@@ -141,6 +144,7 @@ AgentCheck.prototype.warn = function(opts, callback) {
     path: '/agent/check/warn/{id}',
     params: { id: opts.id },
     query: {},
+    method: 'PUT',
   };
 
   if (!opts.id) {
@@ -171,6 +175,7 @@ AgentCheck.prototype.fail = function(opts, callback) {
     path: '/agent/check/fail/{id}',
     params: { id: opts.id },
     query: {},
+    method: 'PUT',
   };
 
   if (!opts.id) {

--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -59,6 +59,7 @@ AgentService.prototype.register = function(opts, callback) {
     path: '/agent/service/register',
     type: 'json',
     body: {},
+    method: 'PUT',
   };
 
   if (!opts.name) {
@@ -102,6 +103,7 @@ AgentService.prototype.deregister = function(opts, callback) {
     name: 'agent.service.deregister',
     path: '/agent/service/deregister/{id}',
     params: { id: opts.id },
+    method: 'PUT',
   };
 
   if (!opts.id) {
@@ -126,6 +128,7 @@ AgentService.prototype.maintenance = function(opts, callback) {
     path: '/agent/service/maintenance/{id}',
     params: { id: opts.id },
     query: { enable: opts.enable },
+    method: 'PUT',
   };
 
   if (!opts.id) {


### PR DESCRIPTION
As mentioned in [https://github.com/silas/node-consul/issues/64](https://github.com/silas/node-consul/issues/64) Consul 1.0.0 has breaking changes with regards to enforcing HTTP verbs on the API endpoints.

This PR updates all the endpoints mentioned in their [changelog](https://github.com/hashicorp/consul/blob/v1.0.0/CHANGELOG.md) to use the correct verbs, the changed endpoints are listed below.

* /agent/join/:address
* /agent/force-leave
* /agent/check/register
* /agent/check/deregister/:check_id
* /agent/check/pass/:check_id
* /agent/check/warn/:check_id
* /agent/check/fail/:check_id
* /agent/service/register
* /agent/service/deregister/:service_id
* /agent/service/maintenance/:service_id

Version 1.0.0 seems to add a few new routes (I have found 3 so far), I have not included those in this PR, I'll submit a second one that completes the 1.0.0 API as its a bit more work.