### PR TITLE
Add connect API

### DIFF
--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -10,6 +10,7 @@
 
 var CatalogNode = require('./catalog/node').CatalogNode;
 var CatalogService = require('./catalog/service').CatalogService;
+var CatalogConnect = require('./catalog/connect').CatalogConnect;
 var utils = require('./utils');
 
 /**
@@ -20,10 +21,12 @@ function Catalog(consul) {
   this.consul = consul;
   this.node = new Catalog.Node(consul);
   this.service = new Catalog.Service(consul);
+  this.connect = new Catalog.Connect(consul);
 }
 
 Catalog.Node = CatalogNode;
 Catalog.Service = CatalogService;
+Catalog.Connect = CatalogConnect;
 
 /**
  * Lists known datacenters

--- a/lib/catalog/connect.js
+++ b/lib/catalog/connect.js
@@ -1,0 +1,54 @@
+/**
+ * Catalog service
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var errors = require('../errors');
+var utils = require('../utils');
+
+/**
+ * Initialize a new `CatalogService` client.
+ */
+
+function CatalogConnect(consul) {
+  this.consul = consul;
+}
+
+/**
+ * Lists the nodes in a given Connect-capable service
+ */
+
+CatalogConnect.prototype.nodes = function(opts, callback) {
+  if (typeof opts === 'string') {
+    opts = { service: opts };
+  }
+
+  opts = utils.normalizeKeys(opts);
+  opts = utils.defaults(opts, this.consul._defaults);
+
+  var req = {
+    name: 'catalog.connect.nodes',
+    path: '/catalog/connect/{service}',
+    params: { service: opts.service },
+    query: {},
+  };
+
+  if (!opts.service) {
+    return callback(this.consul._err(errors.Validation('service required'), req));
+  }
+
+  utils.options(req, opts);
+
+  this.consul._get(req, utils.body, callback);
+};
+
+/**
+ * Module Exports.
+ */
+
+exports.CatalogConnect = CatalogConnect;

--- a/test/catalog.js
+++ b/test/catalog.js
@@ -316,5 +316,29 @@ describe('Catalog', function() {
         });
       });
     });
+
+    describe('connect nodes', function() {
+      it('should work with just string', function(done) {
+        this.nock
+          .get('/v1/catalog/connect/service1')
+          .reply(200, [{ ok: true }]);
+
+        this.consul.catalog.connect.nodes('service1', function(err, data) {
+          should.not.exist(err);
+
+          should(data).eql([{ ok: true }]);
+
+          done();
+        });
+      });
+
+      it('should require service', function(done) {
+        this.consul.catalog.connect.nodes({}, function(err) {
+          should(err).property('message', 'consul: catalog.connect.nodes: service required');
+
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/consul.js
+++ b/test/consul.js
@@ -145,6 +145,8 @@ describe('Consul', function() {
         '  Service',
         '   - list (callback)',
         '   - nodes (callback)',
+        '  Connect',
+        '   - nodes (callback)',
         ' Event',
         '  - fire (callback)',
         '  - list (callback)',


### PR DESCRIPTION
This change adds support for the new `/catalog/connect/:service` API (https://www.consul.io/api/catalog.html#serviceconnect).

Tests are included with full coverage, although I could not get the acceptance tests to run with the instructions given in the Readme.