### PR TITLE
Add consul.catalog register/deregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,10 +765,87 @@ await consul.agent.service.maintenance({ id: "example", enable: true });
 
 ### consul.catalog
 
+- [register](#catalog-register)
+- [deregister](#catalog-deregister)
 - [datacenters](#catalog-datacenters)
 - [connect](#catalog-connect)
 - [node](#catalog-node)
 - [service](#catalog-service)
+
+<a id="catalog-register"></a>
+
+### consul.catalog.register(options)
+
+Registers or updates entries in the catalog.
+
+NOTE: this endpoint is a low-level mechanism for registering or updating entries in the catalog. It is usually preferable to instead use the agent endpoints for registration as they are simpler and perform anti-entropy. It is suggested to read the [catalog API](https://developer.hashicorp.com/consul/api-docs/catalog) documentation before using that.
+
+Options
+
+- id (String, optional): an optional UUID to assign to the node. This must be a 36-character UUID-formatted string
+- node (String, required): specifies the node ID to register
+- address (String, required): specifies the address to register.
+- taggedaddresses (Object, optional): specifies the tagged addresses
+- nodemeta (Object, optional): specifies arbitrary KV metadata pairs for filtering purposes
+- service (Objet, optional): specifies to register a service
+  - id (String): service ID. If ID is not provided, it will be defaulted to the value of the Service.Service property.
+    Only one service with a given ID may be present per node.
+  - service (String): service name
+  - tags (String[], optional): service tags
+  - meta (Object, optional): metadata linked to the service instance
+  - address (String): service IP address
+  - port (Integer): service port
+- check (Object, optional): specifies to register a check.The register API manipulates the health check entry in the Catalog, but it does not setup the
+  TCP/HTTP check to monitor the node's health.
+  - node (String): the node id this check will bind to
+  - name (String): check name
+  - checkid (String): the CheckID can be omitted and will default to the value of Name. The CheckID must be unique on this node.
+  - serviceid (String): if a ServiceID is provided that matches the ID of a service on that node, the check is treated as a service level health check, instead of a node level health check.
+  - notes (String): notes is an opaque field that is meant to hold human-readable text
+  - status (String): initial status. The Status must be one of `passing`, `warning`, or `critical`.
+  - definition (Object): health check definition
+    - http (String): URL endpoint, requires interval
+    - tlsskipverify (Boolean, default: false): skip HTTPS verification
+    - tlsservername (String): SNI
+    - tcp (String): host:port to test, passes if connection is established, fails otherwise
+    - intervalduration (String): interval to run check, requires script (ex: `15s`)
+    - timeoutduration (String): timeout for the check (ex: `10s`)
+    - deregistercriticalserviceafterduration (String): timeout after
+      which to automatically deregister service if check remains in critical state (ex: `120s`)
+- checks (Object[], optional): multiple checks can be provided by replacing `check` with `checks` and sending an array of `check` objects.
+- skipnodeupdate (Bool, optional): pecifies whether to skip updating the node's information in the registration. Note, if the parameter is enabled for a node that doesn't exist, it will still be created
+
+Usage
+
+```javascript
+await consul.catalog.register("example");
+```
+
+<a id="catalog-deregister"></a>
+
+### consul.catalog.deregister(options)
+
+Deregister entries in the catalog.
+
+NOTE:This endpoint is a low-level mechanism for directly removing entries from the Catalog. It is usually preferable to instead use the agent endpoints for deregistration as they are simpler and perform anti-entropy. It is suggested to read the [catalog API](https://developer.hashicorp.com/consul/api-docs/catalog) documentation before using that.
+
+Options
+
+- node (String, required): specifies the ID of the node. If no other values are provided, this node, all its services, and all its checks are removed.
+- checkid (String, optional): specifies the ID of the check to remove.
+- serviceid (String, optional): specifies the ID of the service to remove. The service and all associated checks will be removed.
+
+Usage
+
+```javascript
+await consul.catalog.deregister("example");
+```
+
+or
+
+```javascript
+await consul.catalog.deregister({ id: "example" });
+```
 
 <a id="catalog-datacenters"></a>
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -2,6 +2,7 @@ const CatalogConnect = require("./catalog/connect").CatalogConnect;
 const CatalogNode = require("./catalog/node").CatalogNode;
 const CatalogService = require("./catalog/service").CatalogService;
 const utils = require("./utils");
+const errors = require("./errors");
 
 class Catalog {
   constructor(consul) {
@@ -34,6 +35,67 @@ class Catalog {
    */
   nodes(...args) {
     return this.node.list(...args);
+  }
+
+  /**
+   * Registers or updates entries in the catalog
+   */
+  async register(opts) {
+    if (typeof opts === "string") {
+      opts = { node: opts, address: "127.0.0.1" };
+    }
+
+    opts = utils.normalizeKeys(opts);
+    opts = utils.defaults(opts, this.consul._defaults);
+
+    const req = {
+      name: "catalog.register",
+      path: "/catalog/register",
+      type: "json",
+      body: {},
+    };
+
+    if (!opts.node || !opts.address) {
+      throw this.consul._err(
+        errors.Validation("node and address required"),
+        req
+      );
+    }
+
+    req.body = utils.createCatalogRegistration(opts);
+
+    utils.options(req, opts);
+
+    return await this.consul._put(req, utils.empty);
+  }
+
+  /**
+   * Deregister entries in the catalog
+   */
+  async deregister(opts) {
+    if (typeof opts === "string") {
+      opts = { node: opts };
+    }
+
+    opts = utils.normalizeKeys(opts);
+    opts = utils.defaults(opts, this.consul._defaults);
+
+    const req = {
+      name: "catalog.deregister",
+      path: "/catalog/deregister",
+      type: "json",
+      body: {},
+    };
+
+    if (!opts.node) {
+      throw this.consul._err(errors.Validation("node required"), req);
+    }
+
+    req.body = utils.createCatalogDeregistration(opts);
+
+    utils.options(req, opts);
+
+    return await this.consul._put(req, utils.empty);
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -414,6 +414,116 @@ function _createService(src, isSidecar) {
   return dst;
 }
 
+function _createCatalogService(src) {
+  const dst = {};
+
+  if (src.id) dst.ID = src.id;
+  if (src.service) dst.Service = src.service;
+  if (src.tags) dst.Tags = src.tags;
+  if (src.meta) dst.Meta = src.meta;
+  if (src.hasOwnProperty("address")) dst.Address = src.address;
+  if (src.hasOwnProperty("port")) dst.Port = src.port;
+
+  return dst;
+}
+
+function createCatalogService(src) {
+  return _createCatalogService(normalizeKeys(src));
+}
+
+function _createHealthCheckDefinition(src) {
+  const dst = {};
+
+  if (src.http) {
+    dst.HTTP = src.http;
+    if (src.hasOwnProperty("tlsskipverify"))
+      dst.TLSSkipVerify = src.tlsskipverify;
+    if (src.hasOwnProperty("tlsservername"))
+      dst.TLSServerName = src.tlsservername;
+  } else if (src.tcp) {
+    dst.TCP = src.tcp;
+  } else {
+    throw Error("at least one of http/tcp is required");
+  }
+
+  dst.IntervalDuration = src.intervalduration;
+  if (src.hasOwnProperty("timeoutduration"))
+    dst.TimeoutDuration = src.timeoutduration;
+  if (src.hasOwnProperty("deregistercriticalserviceafterduration")) {
+    dst.DeregisterCriticalServiceAfterDuration =
+      src.deregistercriticalserviceafterduration;
+  }
+
+  return dst;
+}
+
+function createHealthCheckDefininition(src) {
+  return _createHealthCheckDefinition(normalizeKeys(src));
+}
+
+function _createCatalogCheck(src) {
+  const dst = {};
+
+  if (src.hasOwnProperty("checkid")) dst.CheckID = src.checkid;
+  if (src.hasOwnProperty("name")) dst.Name = src.name;
+  if (src.hasOwnProperty("node")) dst.Node = src.node;
+  if (src.hasOwnProperty("serviceid")) dst.ServiceID = src.serviceid;
+  if (src.hasOwnProperty("definition"))
+    dst.Definition = createHealthCheckDefininition(src.definition);
+  if (src.hasOwnProperty("notes")) dst.Notes = src.notes;
+  if (src.hasOwnProperty("status")) dst.Status = src.status;
+
+  return dst;
+}
+
+function createCatalogCheck(src) {
+  return _createCatalogCheck(normalizeKeys(src));
+}
+
+function _createCatalogRegistration(src) {
+  const dst = {};
+
+  if (src.id) dst.ID = src.id;
+  if (src.node) dst.Node = src.node;
+  if (src.nodemeta) dst.NodeMeta = src.nodemeta;
+  if (src.skipnodeupdate) dst.SkipNodeUpdate = src.skipnodeupdate;
+  if (src.hasOwnProperty("address")) dst.Address = src.address;
+
+  if (src.service) dst.Service = createCatalogService(src.service);
+
+  if (Array.isArray(src.checks)) {
+    dst.Checks = src.checks.map(createCatalogCheck);
+  } else if (src.check) {
+    dst.Check = createCatalogCheck(src.check);
+  }
+
+  if (src.taggedaddresses) {
+    dst.TaggedAddresses = _createTaggedAddresses(
+      normalizeKeys(src.taggedaddresses)
+    );
+  }
+
+  return dst;
+}
+
+function _createCatalogDeregistration(src) {
+  const dst = {};
+
+  if (src.node) dst.Node = src.node;
+  if (src.checkid) dst.CheckID = src.checkid;
+  if (src.serviceid) dst.ServiceID = src.serviceid;
+
+  return dst;
+}
+
+function createCatalogRegistration(src) {
+  return _createCatalogRegistration(normalizeKeys(src));
+}
+
+function createCatalogDeregistration(src) {
+  return _createCatalogDeregistration(normalizeKeys(src));
+}
+
 function createService(src) {
   return _createService(normalizeKeys(src));
 }
@@ -493,5 +603,8 @@ exports.setTimeoutContext = setTimeoutContext;
 exports.createServiceCheck = createServiceCheck;
 exports.createService = createService;
 exports.createCheck = createCheck;
+exports.createCatalogRegistration = createCatalogRegistration;
+exports.createCatalogDeregistration = createCatalogDeregistration;
+exports.createCatalogService = createCatalogService;
 exports.hasIndexChanged = hasIndexChanged;
 exports.parseQueryMeta = parseQueryMeta;

--- a/test/catalog.js
+++ b/test/catalog.js
@@ -7,6 +7,60 @@ const helper = require("./helper");
 describe("Catalog", function () {
   helper.setup(this);
 
+  describe("register", function () {
+    it("should work (http) with just string", async function () {
+      this.nock
+        .put("/v1/catalog/register", {
+          Node: "node",
+          Address: "127.0.0.1",
+        })
+        .reply(200);
+
+      await this.consul.catalog.register("node");
+    });
+
+    it("should error (http) on missing required fields", async function () {
+      try {
+        await this.consul.catalog.register({
+          name: "test",
+          serviceid: "service",
+        });
+        should.ok(false);
+      } catch (err) {
+        should(err).property(
+          "message",
+          "consul: catalog.register: node and address required"
+        );
+      }
+    });
+  });
+
+  describe("deregister", function () {
+    it("should work (http) with just string", async function () {
+      this.nock
+        .put("/v1/catalog/deregister", {
+          Node: "node",
+        })
+        .reply(200);
+
+      await this.consul.catalog.deregister("node");
+    });
+
+    it("should error (http) on missing required fields", async function () {
+      try {
+        await this.consul.catalog.deregister({
+          name: "test",
+        });
+        should.ok(false);
+      } catch (err) {
+        should(err).property(
+          "message",
+          "consul: catalog.deregister: node required"
+        );
+      }
+    });
+  });
+
   describe("datacenters", function () {
     it("should work", async function () {
       this.nock.get("/v1/catalog/datacenters").reply(200, [{ ok: true }]);

--- a/test/utils.js
+++ b/test/utils.js
@@ -423,6 +423,182 @@ describe("utils", function () {
     );
   });
 
+  describe("createCatalogDeregistration", function () {
+    it("should work", function () {
+      should(
+        utils.createCatalogDeregistration({
+          node: "node",
+          checkid: "check",
+          serviceid: "service",
+        })
+      ).eql({
+        Node: "node",
+        CheckID: "check",
+        ServiceID: "service",
+      });
+    });
+    it("should work", function () {
+      should(utils.createCatalogDeregistration({})).eql({});
+    });
+  });
+
+  describe("createCatalogRegistration", function () {
+    it("throw on missing grpc/http/tcp", function () {
+      should(() => {
+        utils.createCatalogRegistration({
+          id: "123",
+          node: "node",
+          nodeMeta: { "external-node": "true" },
+          check: {
+            node: "foo",
+            checkID: "service:web1",
+            serviceid: "service",
+            name: "Web HTTP check",
+            definition: {
+              intervalduration: "5s",
+            },
+            notes: "http node check",
+            status: "critical",
+          },
+          service: { id: "service" },
+          address: "10.0.0.1",
+          skipnodeupdate: true,
+        });
+      }).throw("at least one of http/tcp is required");
+    });
+
+    it("should work", function () {
+      should(
+        utils.createCatalogRegistration({
+          id: "123",
+          node: "node",
+          nodeMeta: { "external-node": "true" },
+          check: {
+            node: "foo",
+            checkID: "service:web1",
+            serviceid: "service",
+            name: "Web HTTP check",
+            definition: {
+              http: "http://example.org/",
+              intervalduration: "5s",
+            },
+            notes: "http node check",
+            status: "critical",
+          },
+          service: { id: "service" },
+          address: "10.0.0.1",
+          skipnodeupdate: true,
+        })
+      ).eql({
+        ID: "123",
+        Node: "node",
+        NodeMeta: { "external-node": "true" },
+        Check: {
+          Node: "foo",
+          CheckID: "service:web1",
+          ServiceID: "service",
+          Name: "Web HTTP check",
+          Definition: {
+            HTTP: "http://example.org/",
+            IntervalDuration: "5s",
+          },
+          Notes: "http node check",
+          Status: "critical",
+        },
+        Service: { ID: "service" },
+        Address: "10.0.0.1",
+        SkipNodeUpdate: true,
+      });
+    });
+
+    it("should work", function () {
+      should(
+        utils.createCatalogRegistration({
+          id: "123",
+          node: "node",
+          nodeMeta: { "node-meta": "true" },
+          checks: [
+            {
+              name: "check2",
+              definition: {
+                http: "https://127.0.0.1:8000",
+                tLsskipverify: true,
+                tLsservername: "fqdn",
+                intervalduration: "60s",
+                deregistercriticalserviceafterduration: "120s",
+              },
+            },
+            {
+              name: "check3",
+              definition: {
+                tcp: "127.0.0.1:8000",
+                intervalduration: "60s",
+                timeoutduration: "10s",
+              },
+            },
+            {},
+          ],
+          service: {
+            id: "service",
+            service: "service",
+            tags: [],
+            meta: { defaultContext: "/nodeapi" },
+            address: "127.0.0.1",
+            port: 1234,
+          },
+          address: "10.0.0.1",
+        })
+      ).eql({
+        ID: "123",
+        Node: "node",
+        NodeMeta: { "node-meta": "true" },
+        Checks: [
+          {
+            Name: "check2",
+            Definition: {
+              HTTP: "https://127.0.0.1:8000",
+              TLSSkipVerify: true,
+              TLSServerName: "fqdn",
+              IntervalDuration: "60s",
+              DeregisterCriticalServiceAfterDuration: "120s",
+            },
+          },
+          {
+            Name: "check3",
+            Definition: {
+              TCP: "127.0.0.1:8000",
+              IntervalDuration: "60s",
+              TimeoutDuration: "10s",
+            },
+          },
+          {},
+        ],
+        Service: {
+          Service: "service",
+          ID: "service",
+          Tags: [],
+          Meta: { defaultContext: "/nodeapi" },
+          Address: "127.0.0.1",
+          Port: 1234,
+        },
+        Address: "10.0.0.1",
+      });
+    });
+    should(
+      utils.createCatalogRegistration({
+        taggedaddresses: {},
+      })
+    ).eql({
+      TaggedAddresses: {},
+    });
+  });
+
+  describe("createCatalogService", function () {
+    it("should work", function () {
+      should(utils.createCatalogService({})).eql({});
+    });
+  });
+
   describe("createService", function () {
     it("should work", function () {
       should(


### PR DESCRIPTION
Hello thanks for the work done this project

In our org to support consul-esm we need to register with the catalog (https://developer.hashicorp.com/consul/tutorials/developer-discovery/service-registration-external-services?optInFrom=learn)

This PR adds support for registering and de-registering  entries with the catalog

I thought it would be nice to integrate them in the mainstream project.

thankjs
gianrico 