### PR TITLE
Omit x-consul-token from headers when token is not defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pid
 *swp
 .env
+.idea
 .nyc_output
 .rock.yml
 config

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -172,7 +172,7 @@ function options(req, opts, ignore) {
   if (!req.headers) req.headers = {};
 
   // headers
-  if (opts.token) req.headers["x-consul-token"] = opts.token;
+  if (opts.token && !ignore.token) req.headers["x-consul-token"] = opts.token;
 
   // query
   if (!req.query) req.query = {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -172,8 +172,7 @@ function options(req, opts, ignore) {
   if (!req.headers) req.headers = {};
 
   // headers
-  if (opts.hasOwnProperty("token") && !ignore.token)
-    req.headers["x-consul-token"] = opts.token;
+  if (opts.token) req.headers["x-consul-token"] = opts.token;
 
   // query
   if (!req.query) req.query = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul",
-  "version": "2.0.0-next.1",
+  "version": "2.0.0-next.2",
   "description": "Consul client",
   "main": "./lib",
   "types": "./lib/index.d.ts",

--- a/test/utils.js
+++ b/test/utils.js
@@ -124,13 +124,13 @@ describe("utils", function () {
   });
 
   describe("options", function () {
-    it("should work", function () {
-      const test = (opts, req) => {
-        if (req === undefined) req = {};
-        utils.options(req, opts);
-        return req;
-      };
+    const test = (opts, req) => {
+      if (req === undefined) req = {};
+      utils.options(req, opts);
+      return req;
+    };
 
+    it("should work", function () {
       should(test()).eql({ headers: {}, query: {} });
       should(test({})).eql({ headers: {}, query: {} });
       should(test({ stale: true })).eql({ headers: {}, query: { stale: "1" } });
@@ -181,6 +181,44 @@ describe("utils", function () {
         headers: {},
         query: {},
         timeout: 10000,
+      });
+    });
+
+    describe("when token is undefined", function () {
+      it("should not include x-consul-token header", function () {
+        should(test({ token: undefined })).eql({
+          headers: {},
+          query: {},
+        });
+      });
+    });
+
+    describe("when token is null", function () {
+      it("should not include x-consul-token header", function () {
+        should(test({ token: null })).eql({
+          headers: {},
+          query: {},
+        });
+      });
+    });
+
+    describe("when token is empty string", function () {
+      it("should not include x-consul-token header", function () {
+        should(test({ token: "" })).eql({
+          headers: {},
+          query: {},
+        });
+      });
+    });
+
+    describe("when token is valid value", function () {
+      it("should include x-consul-token header", function () {
+        should(test({ token: "validToken" })).eql({
+          headers: {
+            "x-consul-token": "validToken",
+          },
+          query: {},
+        });
       });
     });
   });


### PR DESCRIPTION
This PR resolves #150

> This library allows the setting consul (authentication) token to be undefined. This is okay, but once you try to send an HTTP/s request with the header x-consul-token: undefined, it screams that undefined is not an allowed value.
> 
> [error="TypeError [ERR_HTTP_INVALID_HEADER_VALUE]: Invalid value "undefined" for header "x-consul-token""]
> I have studied consul lib in Go, and they don't set this header if the value is missing. Understand, that the token is the empty string (as it is the default value for undefined variable of type string in Go. See:
> https://github.com/hashicorp/consul/blob/78e3cbe1562165f891f56c93047031d608ac4ed4/api/api.go#L874C1-L876C3
> 
> I suggest not setting it on the empty string and undefined as well.