### PR TITLE
add support for consul admin partitions via query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const consul = new Consul();
 These options can be included with any method call, although only certain endpoints support them. See the [HTTP API][consul-docs-api] for more information.
 
 - dc (String, optional): datacenter (defaults to local for agent)
+- partition (String, optional): partition (defaults to 'default' partition)
 - wan (Boolean, default: false): return WAN members instead of LAN members
 - consistent (Boolean, default: false): require strong consistency
 - stale (Boolean, default: false): use whatever is available, can be arbitrarily stale

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 exports.DEFAULT_OPTIONS = [
   "consistent",
   "dc",
+  "partition",
   "stale",
   "timeout",
   "token",

--- a/lib/consul.d.ts
+++ b/lib/consul.d.ts
@@ -18,6 +18,7 @@ export interface CommonOptions {
 
 interface DefaultOptions extends CommonOptions {
   dc?: string;
+  partition?: string;
   wan?: boolean;
   consistent?: boolean;
   stale?: boolean;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -178,6 +178,7 @@ function options(req, opts, ignore) {
   if (!req.query) req.query = {};
 
   if (opts.dc && !ignore.dc) req.query.dc = opts.dc;
+  if (opts.partition && !ignore.partition) req.query.partition = opts.partition;
   if (opts.wan && !ignore.wan) req.query.wan = "1";
 
   if (opts.consistent && !ignore.consistent) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -149,6 +149,7 @@ describe("utils", function () {
       should(
         test({
           dc: "dc1",
+          partition: "partition1",
           wan: true,
           consistent: true,
           index: 10,
@@ -166,6 +167,7 @@ describe("utils", function () {
         },
         query: {
           dc: "dc1",
+          partition: "partition1",
           wan: "1",
           consistent: "1",
           index: 10,


### PR DESCRIPTION
- consul admin partitions are a query param that can be specified on most endpoints
- pr adds support for passing it in as an optional query param