### PR TITLE
Added missing CheckID, Name & Notes check parameters

### DIFF
--- a/lib/agent/check.d.ts
+++ b/lib/agent/check.d.ts
@@ -29,7 +29,7 @@ type ListResult = Record<string, Check>;
 
 export interface CheckOptions {
   name: string;
-  id?: string;
+  checkid?: string;
   serviceid?: string;
   http?: string;
   body?: string;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,14 +293,13 @@ function _createTaggedAddresses(src) {
 /**
  * Create node/server-level check object
  * Corresponds to CheckType in Consul Agent Endpoint:
- * https://github.com/hashicorp/consul/blob/master/command/agent/check.go#L43
- * Corresponds to AgentServiceCheck in Consul Go API (which currently omits Notes):
- * https://github.com/hashicorp/consul/blob/master/api/agent.go#L66
- * Currently omits ID and Name fields:
- * https://github.com/hashicorp/consul/issues/2223
+ * https://developer.hashicorp.com/consul/docs/services/usage/checks
  */
 function _createServiceCheck(src) {
   const dst = {};
+  if (src.hasOwnProperty("checkid")) dst.CheckID = src.checkid;
+  if (src.hasOwnProperty("name")) dst.Name = src.name;
+  if (src.hasOwnProperty("notes")) dst.Notes = src.notes;
 
   if (
     (src.grpc ||

--- a/test/utils.js
+++ b/test/utils.js
@@ -810,6 +810,12 @@ describe("utils", function () {
           name: "service",
           checks: [
             { ttl: "10s" },
+            {
+              ttl: "10s",
+              name: "service-check-name-1",
+              checkid: "service-check-id-1",
+              notes: "service-check-notes-1",
+            },
             { http: "http://127.0.0.1:8000", interval: "60s" },
           ],
         }),
@@ -818,6 +824,12 @@ describe("utils", function () {
         Name: "service",
         Checks: [
           { TTL: "10s" },
+          {
+            TTL: "10s",
+            Name: "service-check-name-1",
+            CheckID: "service-check-id-1",
+            Notes: "service-check-notes-1",
+          },
           { HTTP: "http://127.0.0.1:8000", Interval: "60s" },
         ],
       });


### PR DESCRIPTION
Registering a service `global.consul.agent.service.register({})` with `{checks: [{}]}` or `{check: {}}` ignores the `checkid`/`id`, `name` and `notes` params.
However the `global.consul.agent.check.register({})` method do support these fields.
This merge requests enables the `global.consul.agent.check.register()` params in the `global.consul.agent.service.register()` checks field.